### PR TITLE
Fixed owner pointer of compute subarrays

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ LIBRARIES := -L$(BOOST_LIBRARYDIR)
 SRC_DIR := ./src
 OBJ_DIR := ./obj
 SRC_FILES := $(wildcard $(SRC_DIR)/*.cpp)
+HEADER_FILES := $(wildcard $(SRC_DIR)/*.hpp)
 OBJ_FILES := $(patsubst $(SRC_DIR)/%.cpp,$(OBJ_DIR)/%.o,$(SRC_FILES))
 LDFLAGS := $(LIBRARIES) -lboost_system -lboost_program_options
 CPPFLAGS := -g -Wall -std=c++11  $(INCLUDES) 
@@ -26,7 +27,7 @@ $(EXE_FILE_NAME): $(OBJ_FILES)
 loadModules:
 	bash -c "module load boost"
 
-$(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp loadModules
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp $(HEADER_FILES) loadModules
 	g++ $(CPPFLAGS)  $(CXXFLAGS) $(EXTRA_COMPILE_OPTIONS) $(CONFIGURATION_COMPILE_OPTIONS) -fmax-errors=5 -c -o $@ $<
 build: $(EXE_FILE_NAME)
 ########################Main program 
@@ -44,12 +45,14 @@ debug:compile # you need to type run
 clean:
 	rm -rf $(OBJ_DIR)
 	rm -f $(EXE_FILE_NAME)
-	mkdir obj
 	
 release:
 	cp $(EXE_FILE_NAME) bin/$(EXE_FILE_NAME)
 	
-compile: $(EXE_FILE_NAME)
+$(OBJ_DIR):
+	mkdir -p $(OBJ_DIR)	
+
+compile: $(OBJ_DIR) $(EXE_FILE_NAME)
 #########################
 
 

--- a/src/computSubarray.cpp
+++ b/src/computSubarray.cpp
@@ -16,9 +16,9 @@ computSubarray::computSubarray(ID_TYPE l_id, configAndStats * l_confObj, physica
 :physicalComponent(l_id, l_confObj, l_firstDimOwner, l_secondDimOwner, l_thirdDimOwner){
 	//TODO: do initializations specific for the subarray class here
 	memoryArrayObj= new memoryArray(0, l_confObj, this, NULL, NULL);
-	stackedMemoryObj=(stackedMemory*)((layer*)((bank*)firstDimOwner)->firstDimOwner);
 	bankObj = (bank*)firstDimOwner;
-	layerObj= (layer*)((bank*)firstDimOwner->firstDimOwner);
+	layerObj = (layer*)(bankObj->firstDimOwner);
+	stackedMemoryObj = (stackedMemory*)(layerObj->firstDimOwner);
 }
 
 computSubarray::~computSubarray(){

--- a/src/dataPartitioning.hpp
+++ b/src/dataPartitioning.hpp
@@ -36,7 +36,8 @@ class dataPartitioning{
 		assert(randArray!=NULL);
 		for (LOCAL_ADDRESS_TYPE i=0; i<numOFDataElements ;i++){
 
-			randArray[i]= (VALU_T) (rand() % maxRand + minRand);
+			//randArray[i]= (VALU_T) (rand() % maxRand + minRand);
+			randArray[i]= (VALU_T) (rand() % (maxRand - minRand) + minRand);
 		}
 		READ_DATA_TYPE_IN_MEMORY_ARRAY* dataToBePartitionedData= (READ_DATA_TYPE_IN_MEMORY_ARRAY*)randArray;
 		LOCAL_ADDRESS_TYPE sizeOFData=numOFDataElements* sizeof(VALU_T);


### PR DESCRIPTION
1. Fixed stackedMemoryObj owner of computSubarry.
2. Fixed Makefile to recompile object files if any of the header files is modified. Also, creating the OBJ_DIR if not present.
3. Fixed the random number generation range in dataTransfer.hpp.